### PR TITLE
Controller 리턴타입 변경 및 JSON 객체 -> DTO 타입으로 변환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'
+
+	/* JSON 객체 역직렬화에 필요한 ObjectMapper를 사용하기 위해 jackson 라이브러리 의존성 추가 */
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hallym/festival/domain/booth/dto/BoothDTO.java
+++ b/src/main/java/com/hallym/festival/domain/booth/dto/BoothDTO.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
@@ -29,7 +30,7 @@ public class BoothDTO {
     @NotEmpty
     private String writer;
 
-    @NotEmpty
+    @NotNull
     private BoothType booth_type;
 
     private Boolean active;

--- a/src/main/java/com/hallym/festival/domain/booth/entity/BoothType.java
+++ b/src/main/java/com/hallym/festival/domain/booth/entity/BoothType.java
@@ -1,5 +1,12 @@
 package com.hallym.festival.domain.booth.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum BoothType {
-    주점, 푸드트럭, 부스, 플리마켓
+    주점, 푸드트럭, 부스, 플리마켓;
+
+    @JsonCreator
+    public static BoothType from(String s) {
+        return BoothType.valueOf(s);
+    }
 }

--- a/src/main/java/com/hallym/festival/domain/visitComment/controller/VisitCommentController.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/controller/VisitCommentController.java
@@ -1,7 +1,6 @@
-package com.hallym.festival.domain.visitComment.controller;
+package com.hallym.festival.domain.visitcomment.controller;
 
 import com.hallym.festival.domain.comment.dto.CommentPasswordDto;
-import com.hallym.festival.domain.visitComment.service.VisitCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,11 +8,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/visitComment")
 @RestController
 public class VisitCommentController {
-    private final VisitCommentService visitCommentService;
-
-    @DeleteMapping("/{id}")
-    public String deleteComment(@PathVariable Long id, @RequestBody
-    CommentPasswordDto password) {
-        return visitCommentService.delete(id, password);
-    }
+//    private final VisitCommentService visitCommentService;
+//
+//    @DeleteMapping("/{id}")
+//    public String deleteComment(@PathVariable Long id, @RequestBody
+//    CommentPasswordDto password) {
+//        return visitCommentService.delete(id, password);
+//    }
 }

--- a/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentPasswordDto.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentPasswordDto.java
@@ -1,4 +1,4 @@
-package com.hallym.festival.domain.visitComment.dto;
+package com.hallym.festival.domain.visitcomment.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentRequestDto.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentRequestDto.java
@@ -1,4 +1,4 @@
-package com.hallym.festival.domain.visitComment.dto;
+package com.hallym.festival.domain.visitcomment.dto;
 
 import com.hallym.festival.domain.booth.entity.Booth;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentResponseDto.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentResponseDto.java
@@ -1,4 +1,4 @@
-package com.hallym.festival.domain.visitComment.dto;
+package com.hallym.festival.domain.visitcomment.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/hallym/festival/domain/visitComment/entity/VisitComment.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/entity/VisitComment.java
@@ -1,4 +1,4 @@
-package com.hallym.festival.domain.visitComment.entity;
+package com.hallym.festival.domain.visitcomment.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.hallym.festival.domain.booth.entity.Booth;

--- a/src/main/java/com/hallym/festival/domain/visitComment/repository/VisitCommentRepository.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/repository/VisitCommentRepository.java
@@ -1,10 +1,12 @@
-package com.hallym.festival.domain.visitComment.repository;
+package com.hallym.festival.domain.visitcomment.repository;
 
-import com.hallym.festival.domain.visitComment.entity.VisitComment;
+
+import com.hallym.festival.domain.visitcomment.entity.VisitComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface VisitCommentRepository extends JpaRepository<VisitComment, Long> {
-    List<VisitComment> findByBooth_IdAndActiveOrderByCreatedDateTimeDesc(Long id, Boolean active);
+//    List<VisitComment> findByBooth_IdAndActiveOrderByCreatedDateTimeDesc(Long id, Boolean active);
+
 }

--- a/src/main/java/com/hallym/festival/domain/visitComment/service/VisitCommentService.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/service/VisitCommentService.java
@@ -1,4 +1,4 @@
-package com.hallym.festival.domain.visitComment.service;
+package com.hallym.festival.domain.visitcomment.service;
 
 public class VisitCommentService {
 }

--- a/src/main/java/com/hallym/festival/global/config/StringRequestDTOConverter.java
+++ b/src/main/java/com/hallym/festival/global/config/StringRequestDTOConverter.java
@@ -1,0 +1,31 @@
+package com.hallym.festival.global.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hallym.festival.domain.booth.dto.BoothDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+@Component
+@Log4j2
+public class StringRequestDTOConverter extends Throwable implements Converter<String, BoothDTO> { //Throwable 인터페이스. String -> BoothDTO 타입변환
+
+    ObjectMapper objectMapper = new ObjectMapper(); //JSON 객체를 deserialization하기 위한 클래스
+    BoothDTO boothDTO; //역직렬화 시킬 클래스
+
+    public StringRequestDTOConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public BoothDTO convert(String convertTarget) {
+        try{
+            boothDTO = objectMapper.readValue(convertTarget, new TypeReference<BoothDTO>() { // 변환할 대상 , BoothDTO 클래스 타입으로 변환 후 레퍼런스 반환
+            });
+        }catch (JsonProcessingException e){
+            log.info(e);
+        }
+        return boothDTO;
+    }
+}


### PR DESCRIPTION
#  작업내용

### 1. VisitComment 도메인 import 정보 변경
- 패키지 명 변경 시 일괄 적용되지 않은 것으로 확인
- 존재하지 않는 메소드 주입 부분 삭제

### 2. BoothController의 리턴타입을 Map<String,String>으로 변경
![image](https://user-images.githubusercontent.com/80760160/226534415-b68c438b-4f13-4e3e-9b26-1083965b991c.png)


### 3. Enum 클래스에 request로 받은 String을 Enum Type으로 변환하는 메소드 추가
- 미변환 시 DTO에 값이 담기지 않아서 Controller에 전달이 안된다.
```java
  @JsonCreator
    public static BoothType from(String s) {
        return BoothType.valueOf(s);
    }
```
### 4.  JSON 역직렬화 클래스 작성
- JSON 객체 역직렬화에 필요한 ObjectMapper를 사용하기 위해 jackson 라이브러리 의존성 추가
``` build.gradle
	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
```
``` java
        ObjectMapper objectMapper = new ObjectMapper();
```
- StringRequestDTOConverter 클래스 생성
```java
 boothDTO = objectMapper.readValue(convertTarget, new TypeReference<BoothDTO>() { 
// (변환할 대상을 매개변수로 받고 , BoothDTO 클래스 타입으로 변환 후 레퍼런스 반환
```
---
# 미리보기(첨부)
![image](https://user-images.githubusercontent.com/80760160/226534128-2b7fe272-57ab-4e68-a0b3-7f02265dcf49.png)

- closed #24 