### PR TITLE
신고기능 구현

### DIFF
--- a/src/main/java/com/hallym/festival/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hallym/festival/domain/comment/controller/CommentController.java
@@ -5,9 +5,7 @@ import com.hallym.festival.domain.comment.dto.CommentRequestDto;
 import com.hallym.festival.domain.comment.dto.CommentResponseDto;
 import com.hallym.festival.domain.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +34,7 @@ public class CommentController {
         String result = commentService.delete(commentId, pwd);
         return Map.of("result", result);
     }
+
 }
 
 

--- a/src/main/java/com/hallym/festival/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hallym/festival/domain/comment/entity/Comment.java
@@ -1,13 +1,15 @@
 package com.hallym.festival.domain.comment.entity;
 
-
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.hallym.festival.domain.booth.entity.Booth;
+import com.hallym.festival.domain.report.entity.Report;
 import com.hallym.festival.global.baseEntity.BaseTimeEntity;
 import lombok.*;
 import org.jetbrains.annotations.NotNull;
-
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -32,6 +34,10 @@ public class Comment extends BaseTimeEntity {
 
     @NotNull
     private Boolean active;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    private List<Report> reportList = new ArrayList<Report>();
 
     @NotNull
     @JsonBackReference

--- a/src/main/java/com/hallym/festival/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hallym/festival/domain/comment/service/CommentService.java
@@ -8,14 +8,11 @@ import com.hallym.festival.domain.comment.dto.CommentResponseDto;
 import com.hallym.festival.domain.comment.entity.Comment;
 import com.hallym.festival.domain.comment.repository.CommentRepository;
 import com.hallym.festival.global.exception.WrongBoothId;
-import com.hallym.festival.global.exception.WrongCommentId;
 import com.hallym.festival.global.security.Encrypt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 import java.util.List;

--- a/src/main/java/com/hallym/festival/domain/likes/service/LikeService.java
+++ b/src/main/java/com/hallym/festival/domain/likes/service/LikeService.java
@@ -41,7 +41,7 @@ public class LikeService {
             return "like delete success";
         }
         else { //쿠키가 없을 경우 추가
-            LikesResponseDto likes = create(bno);
+            LikesResponseDto likes = createCookie(bno);
             Cookie keyCookie = new Cookie(bno.toString(), likes.getCookieKey());
             keyCookie.setMaxAge(14*60*60*24); // 2주일
             keyCookie.setPath("/");
@@ -50,7 +50,7 @@ public class LikeService {
         }
     }
 
-    public LikesResponseDto create(Long boothId) {
+    public LikesResponseDto createCookie(Long boothId) {
         Optional<Booth> byId = boothRepository.findById(boothId);
         if (byId.isEmpty()) {
             throw new WrongBoothId();

--- a/src/main/java/com/hallym/festival/domain/report/controller/ReportController.java
+++ b/src/main/java/com/hallym/festival/domain/report/controller/ReportController.java
@@ -1,0 +1,29 @@
+package com.hallym.festival.domain.report.controller;
+
+import com.hallym.festival.domain.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/report")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping("{cno}")
+    public Map<String, String> reportComment(
+            @PathVariable(name = "cno") Long commentId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        String result = reportService.report(commentId, request, response);
+        return Map.of("result", result);
+    }
+
+}

--- a/src/main/java/com/hallym/festival/domain/report/entity/Report.java
+++ b/src/main/java/com/hallym/festival/domain/report/entity/Report.java
@@ -1,0 +1,30 @@
+package com.hallym.festival.domain.report.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.hallym.festival.domain.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Report {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Rno;
+
+    @NotNull
+    private String cookieKey;
+
+    @NotNull
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}

--- a/src/main/java/com/hallym/festival/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/hallym/festival/domain/report/repository/ReportRepository.java
@@ -1,0 +1,12 @@
+package com.hallym.festival.domain.report.repository;
+
+import com.hallym.festival.domain.comment.entity.Comment;
+import com.hallym.festival.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    Optional<Report> findByCookieKey(String CookieKey);
+    Long countByComment(Comment comment);
+}

--- a/src/main/java/com/hallym/festival/domain/report/service/ReportService.java
+++ b/src/main/java/com/hallym/festival/domain/report/service/ReportService.java
@@ -1,0 +1,93 @@
+package com.hallym.festival.domain.report.service;
+
+import com.hallym.festival.domain.comment.entity.Comment;
+import com.hallym.festival.domain.comment.repository.CommentRepository;
+import com.hallym.festival.domain.report.entity.Report;
+import com.hallym.festival.domain.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import java.util.Random;
+
+@Service
+@Transactional
+@Log4j2
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final CommentRepository commentRepository;
+    private final ReportRepository reportRepository;
+
+    public String report(Long commentId, HttpServletRequest request, HttpServletResponse response) {
+        Optional<Cookie> commentCookie = findCommentCookie(request, commentId);
+        if (commentCookie.isPresent()) { //쿠키가 있을경우 return
+            return "already reported";
+        }
+        //쿠키가 없을경우 추가.
+        else {
+            Optional<Comment> byId = commentRepository.findById(commentId);
+            if (byId.isEmpty()) {
+                throw new RuntimeException();
+            }
+            Comment comment = byId.get();
+            Long reportCount = reportRepository.countByComment(comment);
+            if (reportCount >= 2) {
+                comment.setActivte(Boolean.FALSE);
+                return "report success and comment deleted";
+            }
+            else {
+                Report report = createCookie(comment);
+                Cookie keyCookie = new Cookie(commentId.toString(), report.getCookieKey());
+                keyCookie.setMaxAge(14*60*60*24);
+                keyCookie.setPath("/");
+                response.addCookie(keyCookie);
+                return "report success";
+            }
+        }
+    }
+
+    public Optional<Cookie> findCommentCookie(HttpServletRequest request, Long commentId) {
+        Cookie[] userCookies = request.getCookies();
+        if (userCookies == null) {
+            return Optional.empty();
+        }
+        for (Cookie userCookie : userCookies) {
+            if (userCookie.getName().equals(commentId.toString())) {
+                return Optional.of(userCookie); //null값이 안들어가게
+            }
+        }
+        return Optional.empty();
+    }
+
+    public Report createCookie(Comment comment) {
+        String newCookieKey = createCookieKey();
+        Report report = Report.builder().comment(comment).cookieKey(newCookieKey).build();
+        reportRepository.save(report);
+        return report;
+    }
+
+    private String createCookieKey(){
+        while (true) {
+            String cookieKey = createRandomString();
+            Optional<Report> report = reportRepository.findByCookieKey(cookieKey);
+            if (report.isEmpty()){
+                return cookieKey;
+            }
+        }
+    }
+
+    private String createRandomString(){
+        int targetStringLength = 10;
+        Random random = new Random();
+        return random.ints(97, 123)
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     open-in-view: true
     generate-ddl : true
     hibernate:
-      ddl-auto: create # db 컬럼과 일치하는지 확인
+      ddl-auto: update # db 컬럼과 일치하는지 확인
     properties:
       hibernate:
         format_sql: true # 로그 출력


### PR DESCRIPTION
# 신고기능은 댓글기능의 자식테이블로 만들었다.
- 서로 연관관계 매핑을 해줌
- 도메인 분리
---
# 로직은 어떻게 짯는지
- CookieKey 값으로 클라이언트 구분.
- `/report/{cno}` 로 post요청 날리면 댓글에 매핑된 report entity 하나생성
- report entity가 댓글에 3개이상 있으면 댓글 삭제처리. 
---
# 반환되는 값
- 신고했을때
![image](https://user-images.githubusercontent.com/52206904/227579614-72e93491-8182-4ef1-bd34-46aba711c5ee.png)
- 동일한 클라이언트가 신고했을때(해당 댓글에 쿠키값이 있는 사용자) 
![image](https://user-images.githubusercontent.com/52206904/227579073-d92b412e-bc2e-45e7-a653-ee6c49a3cdec.png)
- 3회 신고했을때
![image](https://user-images.githubusercontent.com/52206904/227578336-3f032cb5-13ae-4e17-b0ec-50f83a26b893.png)

---
- closed #32 