### PR TITLE
Querydsl를 이용한 검색과 페이징 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+
+buildscript { //gradle이 특정 task를 실행할 때 사용
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.9'
@@ -57,9 +64,28 @@ dependencies {
 	/* Thumbnail 파일 처리를 위한 의존성 */
 	implementation 'net.coobird:thumbnailator:0.4.17'
 
+   /* 동적 쿼리를 사용한 페이징과 검색 처리를 위해 querydsl 의존성 추가*/
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+
+	annotationProcessor(
+
+			"javax.persistence:javax.persistence-api",
+
+			"javax.annotation:javax.annotation-api",
+
+			"com.querydsl:querydsl-apt:${queryDslVersion}:jpa")
+
 
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+sourceSets {
+	main {
+		java {
+			srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+		}
+	}
 }

--- a/src/main/java/com/hallym/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/hallym/festival/domain/booth/controller/BoothController.java
@@ -1,7 +1,8 @@
 package com.hallym.festival.domain.booth.controller;
 
 import com.hallym.festival.domain.booth.dto.BoothDTO;
-import com.hallym.festival.domain.booth.entity.Booth;
+import com.hallym.festival.domain.booth.dto.PageRequestDTO;
+import com.hallym.festival.domain.booth.dto.PageResponseDTO;
 import com.hallym.festival.domain.booth.service.BoothService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -10,7 +11,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.List;
 import java.util.Map;
 import javax.validation.Valid;
 
@@ -23,8 +23,13 @@ public class BoothController {
     private final BoothService boothService;
 
     @GetMapping(value = "/list", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Booth> getAllBooths() {
-        return boothService.getList();
+    public PageResponseDTO<BoothDTO> list(PageRequestDTO pageRequestDTO){
+
+        PageResponseDTO<BoothDTO> responseDTO = boothService.list(pageRequestDTO);
+
+        log.info(responseDTO);
+
+        return responseDTO;
     }
 
     @GetMapping("/{bno}")

--- a/src/main/java/com/hallym/festival/domain/booth/dto/PageRequestDTO.java
+++ b/src/main/java/com/hallym/festival/domain/booth/dto/PageRequestDTO.java
@@ -27,20 +27,20 @@ public class PageRequestDTO {
 
     private String keyword;
 
-    public String[] getTypes(){
+    public String[] getTypes(){ //boardRepository에서 String[]으로 반환하기 때문에 배열 반환
         if(type == null || type.isEmpty()){
             return null;
         }
         return type.split("");
     }
 
-    public Pageable getPageable(String...props) {
+    public Pageable getPageable(String...props) { //페이징 처리를 위해 Pageable 타입 반환
         return PageRequest.of(this.page -1, this.size, Sort.by(props).descending());
     }
 
     private String link;
 
-    public String getLink() {
+    public String getLink() { //검색 조건과 페이징 조건 들을 문자열로 구성
 
         if(link == null){
             StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/hallym/festival/domain/booth/dto/PageResponseDTO.java
+++ b/src/main/java/com/hallym/festival/domain/booth/dto/PageResponseDTO.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 @ToString
-public class PageResponseDTO<E> {
+public class PageResponseDTO<E> { //다른 도메인에서도 페이징 처리를 할 수 있게 제네릭 처리
 
     private int page;
     private int size;
@@ -27,7 +27,7 @@ public class PageResponseDTO<E> {
     private List<E> dtoList;
 
     @Builder(builderMethodName = "withAll")
-    public PageResponseDTO(PageRequestDTO pageRequestDTO, List<E> dtoList, int total){
+    public PageResponseDTO(PageRequestDTO pageRequestDTO, List<E> dtoList, int total){ //여러 정보를 생성자를 이용해서 받아서 처리하는 것이 안전
 
         if(total <= 0){
             return;
@@ -39,17 +39,17 @@ public class PageResponseDTO<E> {
         this.total = total;
         this.dtoList = dtoList;
 
-        this.end =   (int)(Math.ceil(this.page / 10.0 )) *  10;
+        this.end =   (int)(Math.ceil(this.page / 10.0 )) *  10; //마지막 페이지
 
-        this.start = this.end - 9;
+        this.start = this.end - 9; //시작 페이지
 
-        int last =  (int)(Math.ceil((total/(double)size)));
+        int last =  (int)(Math.ceil((total/(double)size))); //마지막 페이지 전체 개수
 
-        this.end =  end > last ? last: end;
+        this.end =  end > last ? last: end; //마지막 페이지가 last 값보다 작은 경우에 last값이 end
 
-        this.prev = this.start > 1;
+        this.prev = this.start > 1; //이전 페이지는 시작 페이지가 1이 아니라면 무조건 true
 
-        this.next =  total > this.end * this.size;
+        this.next =  total > this.end * this.size; //마지막 페이지와 페이지당 개수를 곱한 값보다 전체 개수가 많은가?
 
     }
 }

--- a/src/main/java/com/hallym/festival/domain/booth/entity/Booth.java
+++ b/src/main/java/com/hallym/festival/domain/booth/entity/Booth.java
@@ -2,6 +2,8 @@ package com.hallym.festival.domain.booth.entity;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.hallym.festival.domain.comment.entity.Comment;
+import com.hallym.festival.domain.likes.entity.Likes;
+import com.hallym.festival.domain.menu.entity.Menu;
 import com.hallym.festival.global.baseEntity.BaseTimeEntity;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -80,12 +82,14 @@ public class Booth extends BaseTimeEntity {
     }
 
 
-//    @JsonManagedReference
-//    @OneToMany(mappedBy = "booth")
-//    private List<Menu> menus = new ArrayList<>();
+    @Builder.Default
+    @JsonManagedReference
+    @OneToMany(mappedBy = "booth")
+    private List<Menu> menus = new ArrayList<>();
 
-//    @OneToMany(mappedBy = "booth")
-//    private List<Like> likes = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "booth")
+    private List<Likes> likes = new ArrayList<>();
 
     //test를 위한 change 함수
     public void change(String booth_title, String booth_content, String writer, BoothType booth_type, boolean active){

--- a/src/main/java/com/hallym/festival/domain/booth/repository/BoothRepository.java
+++ b/src/main/java/com/hallym/festival/domain/booth/repository/BoothRepository.java
@@ -1,6 +1,7 @@
 package com.hallym.festival.domain.booth.repository;
 
 import com.hallym.festival.domain.booth.entity.Booth;
+import com.hallym.festival.domain.booth.repository.boothSearch.BoothSearch;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,10 +10,12 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface BoothRepository extends JpaRepository<Booth, Long> {
+public interface BoothRepository extends JpaRepository<Booth, Long>, BoothSearch {
     //EntityGraph를 이용해서 lazy 로딩이여도 한 번에 join 처리 후, select 실행
     @EntityGraph(attributePaths = {"imageSet"}) //imageSet 속성을 같이 로딩
     @Query("select b from Booth b where b.bno =:bno")
     Optional<Booth> findByIdWithImages(Long bno);
+
+
 
 }

--- a/src/main/java/com/hallym/festival/domain/booth/repository/boothSearch/BoothSearch.java
+++ b/src/main/java/com/hallym/festival/domain/booth/repository/boothSearch/BoothSearch.java
@@ -1,0 +1,13 @@
+package com.hallym.festival.domain.booth.repository.boothSearch;
+
+import com.hallym.festival.domain.booth.entity.Booth;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoothSearch {
+
+    Page<Booth> search1(Pageable pageable);
+
+    Page<Booth> searchAll(String[] types, String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/hallym/festival/domain/booth/repository/boothSearch/BoothSearchImpl.java
+++ b/src/main/java/com/hallym/festival/domain/booth/repository/boothSearch/BoothSearchImpl.java
@@ -1,0 +1,90 @@
+package com.hallym.festival.domain.booth.repository.boothSearch;
+
+import com.hallym.festival.domain.booth.entity.Booth;
+import com.hallym.festival.domain.booth.entity.QBooth;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class BoothSearchImpl extends QuerydslRepositorySupport implements BoothSearch {
+
+    public BoothSearchImpl(){
+        super(Booth.class);
+    }
+
+    @Override
+    public Page<Booth> search1(Pageable pageable) {
+
+        QBooth booth = QBooth.booth;
+
+        JPQLQuery<Booth> query = from(booth); //@Query로 생성했던 JPQL을 코드로 생성
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder(); // (
+
+        booleanBuilder.or(booth.booth_title.contains("11")); // title like ...
+
+        booleanBuilder.or(booth.booth_content.contains("11")); // content like ....
+
+        query.where(booleanBuilder);
+        query.where(booth.bno.gt(0L)); //bno가 0보다 큰 조건
+
+
+        //paging
+        this.getQuerydsl().applyPagination(pageable, query);
+
+        List<Booth> list = query.fetch(); //JPQLQuery 실행
+
+        long count = query.fetchCount(); //fetchCount()로 count 쿼리 실행
+
+
+        return null;
+
+    }
+
+    @Override
+    public Page<Booth> searchAll(String[] types, String keyword, Pageable pageable) {
+
+        QBooth booth = QBooth.booth;
+        JPQLQuery<Booth> query = from(booth);
+
+        if( (types != null && types.length > 0) && keyword != null ){ //검색 조건과 키워드가 있다면
+
+            BooleanBuilder booleanBuilder = new BooleanBuilder(); // (
+
+            for(String type: types){
+
+                switch (type){
+                    case "t":
+                        booleanBuilder.or(booth.booth_title.contains(keyword));
+                        break;
+                    case "c":
+                        booleanBuilder.or(booth.booth_content.contains(keyword));
+                        break;
+                    case "w":
+                        booleanBuilder.or(booth.writer.contains(keyword));
+                        break;
+                }
+            }//end for
+            query.where(booleanBuilder);
+        }//end if
+
+        //bno > 0
+        query.where(booth.bno.gt(0L));
+
+        //paging
+        this.getQuerydsl().applyPagination(pageable, query);
+
+        List<Booth> list = query.fetch();
+
+        long count = query.fetchCount();
+
+        return new PageImpl<>(list, pageable, count);
+        //페이징의 최종 처리는 Page<T>타입을 반환합니다. (실제 목록 데이터, 페이지 정보를 가진 객체, 전체개수)
+
+    }
+}

--- a/src/main/java/com/hallym/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/hallym/festival/domain/booth/service/BoothService.java
@@ -1,6 +1,8 @@
 package com.hallym.festival.domain.booth.service;
 
 import com.hallym.festival.domain.booth.dto.BoothDTO;
+import com.hallym.festival.domain.booth.dto.PageRequestDTO;
+import com.hallym.festival.domain.booth.dto.PageResponseDTO;
 import com.hallym.festival.domain.booth.entity.Booth;
 
 import java.util.List;
@@ -11,7 +13,7 @@ public interface BoothService {
 
     BoothDTO getOne(Long bno);
 
-    List<Booth> getList();
+    PageResponseDTO<BoothDTO> list(PageRequestDTO pageRequestDTO);
 
     void modify(BoothDTO boothDTO);
 

--- a/src/main/java/com/hallym/festival/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hallym/festival/domain/comment/repository/CommentRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-//    @Query("select r from Comment r where r.booth.bno = :bno") //게시물 삭제 시 댓글들 삭제를 위한 쿼리
     List<Comment> findByBooth_BnoAndActiveOrderByRegDateDesc(Long bno, Boolean active);
 
     void deleteByBooth_Bno(Long bno);

--- a/src/main/java/com/hallym/festival/domain/visitComment/controller/VisitCommentController.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/controller/VisitCommentController.java
@@ -1,9 +1,8 @@
 package com.hallym.festival.domain.visitComment.controller;
 
 
-import com.hallym.festival.domain.visitComment.dto.VisitCommentRequestDto;
-import com.hallym.festival.domain.visitComment.dto.VisitCommentResponseDto;
 import com.hallym.festival.domain.visitComment.service.VisitCommentService;
+import com.hallym.festival.domain.visitComment.dto.VisitCommentResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -21,12 +20,12 @@ public class VisitCommentController {
     private final VisitCommentService visitCommentService;
 
     @GetMapping(value = "list", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<VisitCommentResponseDto> getVisitCommentList() {
+    public List<VisitCommentResponseDTO> getVisitCommentList() {
         return visitCommentService.getAll();
     }
     @PostMapping("/create")
     public Map<String, String> createVisitComment
-            (@Valid @RequestBody VisitCommentRequestDto visitCommentRequestDto, HttpServletRequest request){
+            (@Valid @RequestBody com.hallym.festival.domain.visitComment.dto.VisitCommentRequestDTO visitCommentRequestDto, HttpServletRequest request){
         visitCommentService.create(visitCommentRequestDto, request);
         return Map.of("result", "create success");
     }

--- a/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentRequestDto.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentRequestDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class VisitCommentRequestDto extends BaseTimeEntity {
+public class VisitCommentRequestDTO{
 
     private String ip;
 

--- a/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentResponseDto.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/dto/VisitCommentResponseDto.java
@@ -4,16 +4,16 @@ import com.hallym.festival.global.baseEntity.BaseTimeEntity;
 import lombok.*;
 
 
-
 @Data
 @ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class VisitCommentResponseDto extends BaseTimeEntity {
+public class VisitCommentResponseDTO{
 
     private Long vno;
     private String visit_content;
     private String ip;
     private Boolean active;
+
 }

--- a/src/main/java/com/hallym/festival/domain/visitComment/service/VisitCommentService.java
+++ b/src/main/java/com/hallym/festival/domain/visitComment/service/VisitCommentService.java
@@ -1,8 +1,7 @@
 package com.hallym.festival.domain.visitComment.service;
 
-import com.hallym.festival.domain.visitComment.dto.VisitCommentRequestDto;
-import com.hallym.festival.domain.visitComment.dto.VisitCommentResponseDto;
 import com.hallym.festival.domain.visitComment.entity.VisitComment;
+import com.hallym.festival.domain.visitComment.dto.VisitCommentResponseDTO;
 import com.hallym.festival.domain.visitComment.repository.VisitCommentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,13 +23,13 @@ public class VisitCommentService {
     private final VisitCommentRepository visitCommentRepository;
     private final ModelMapper modelMapper;
 
-    public List<VisitCommentResponseDto> getAll() {
+    public List<VisitCommentResponseDTO> getAll() {
         List<VisitComment> visitComments = visitCommentRepository.findByActiveOrderByRegDateDesc(Boolean.TRUE);
         return getResponseDtoList(visitComments);
     }
 
     @Transactional
-    public void create(VisitCommentRequestDto visitCommentRequestDto, HttpServletRequest request) {
+    public void create(com.hallym.festival.domain.visitComment.dto.VisitCommentRequestDTO visitCommentRequestDto, HttpServletRequest request) {
 
         visitCommentRequestDto.setIp(getRemoteAddr(request));
         visitCommentRequestDto.setActive(Boolean.TRUE);
@@ -49,11 +48,11 @@ public class VisitCommentService {
         return "delete success";
     }
 
-    public VisitCommentResponseDto entityToResponseDto(VisitComment visitComment) {
-        return modelMapper.map(visitComment, VisitCommentResponseDto.class);
+    public VisitCommentResponseDTO entityToResponseDto(VisitComment visitComment) {
+        return modelMapper.map(visitComment, VisitCommentResponseDTO.class);
     }
 
-    private List<VisitCommentResponseDto> getResponseDtoList(List<VisitComment> all) {
+    private List<VisitCommentResponseDTO> getResponseDtoList(List<VisitComment> all) {
         return all.stream().map(visitComment -> this.entityToResponseDto(visitComment)) //this::entityToResponseDto 랑 같음
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/hallym/festival/repository/BoothRepositoryTests.java
+++ b/src/test/java/com/hallym/festival/repository/BoothRepositoryTests.java
@@ -9,9 +9,14 @@ import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.Commit;
 
 import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -94,6 +99,26 @@ public class BoothRepositoryTests {
 
 	}
 
+	@Test
+	public void testPaging() {
+
+		//1 page order by bno desc
+		Pageable pageable = PageRequest.of(0,10, Sort.by("bno").descending());
+
+		Page<Booth> result = boothRepository.findAll(pageable);
+
+
+		log.info("total count: "+result.getTotalElements());
+		log.info( "total pages:" +result.getTotalPages());
+		log.info("page number: "+result.getNumber());
+		log.info("page size: "+result.getSize());
+
+		List<Booth> todoList = result.getContent();
+
+		todoList.forEach(booth -> log.info(booth));
+
+	}
+
 	//첨부파일이 있는 게시물 등록 테스트
 	@Test
 	public void testInsertWithImages() {
@@ -169,6 +194,7 @@ public class BoothRepositoryTests {
 
 	}
 
+	//첨부파일 삭제
 	@Test
 	@Transactional
 	@Commit

--- a/src/test/java/com/hallym/festival/repository/BoothRepositoryTests.java
+++ b/src/test/java/com/hallym/festival/repository/BoothRepositoryTests.java
@@ -176,9 +176,61 @@ public class BoothRepositoryTests {
 
 		Long bno = 1L;
 
-		commentRepository.deleteByBooth_Bno(bno);
+//		commentRepository.deleteByBooth_Bno(bno);
+//
+//		boothRepository.deleteById(bno);
 
-		boothRepository.deleteById(bno);
+		//삭제가 아니라 is_deleted 만 변경
 
+	}
+
+
+	@Test
+	public void testSearch1() {
+
+		//2 page order by bno desc
+		Pageable pageable = PageRequest.of(1,10, Sort.by("bno").descending());
+
+		boothRepository.search1(pageable);
+
+	}
+
+	@Test
+	public void testSearchAll() {
+
+		String[] types = {"t","c","w"};
+
+		String keyword = "1";
+
+		Pageable pageable = PageRequest.of(0,10, Sort.by("bno").descending());
+
+		Page<Booth> result = boothRepository.searchAll(types, keyword, pageable );
+
+	}
+
+	@Test
+	public void testSearchAll2() {
+
+		String[] types = {"t","c","w"};
+
+		String keyword = "1";
+
+		Pageable pageable = PageRequest.of(0,10, Sort.by("bno").descending());
+
+		Page<Booth> result = boothRepository.searchAll(types, keyword, pageable );
+
+		//total pages
+		log.info(result.getTotalPages());
+
+		//pag size
+		log.info(result.getSize());
+
+		//pageNumber
+		log.info(result.getNumber());
+
+		//prev next
+		log.info(result.hasPrevious() +": " + result.hasNext());
+
+		result.getContent().forEach(board -> log.info(board));
 	}
 }

--- a/src/test/java/com/hallym/festival/service/BoothServiceTests.java
+++ b/src/test/java/com/hallym/festival/service/BoothServiceTests.java
@@ -1,6 +1,8 @@
 package com.hallym.festival.service;
 
 import com.hallym.festival.domain.booth.dto.BoothDTO;
+import com.hallym.festival.domain.booth.dto.PageRequestDTO;
+import com.hallym.festival.domain.booth.dto.PageResponseDTO;
 import com.hallym.festival.domain.booth.entity.BoothType;
 import com.hallym.festival.domain.booth.service.BoothService;
 import lombok.extern.log4j.Log4j2;
@@ -70,5 +72,21 @@ public class BoothServiceTests {
         boothService.remove(bno);
 
         log.info(boothService.getOne(bno));
+    }
+
+    @Test
+    public void testList() {
+
+        PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
+                .type("tcw")
+                .keyword("1")
+                .page(1)
+                .size(10)
+                .build();
+
+        PageResponseDTO<BoothDTO> responseDTO = boothService.list(pageRequestDTO);
+
+        log.info(responseDTO);
+
     }
 }


### PR DESCRIPTION
## ☑️ Describe your changes
-  Querydsl를 사용한 검색 기능 구현 
> BoothSearch 인터페이스와 BoothSearchImpl 구현체 구조 형성
> 검색 테스트 코드 작성
- 기존의 Booth 목록 조회 기능을 페이징을 포함한 list형태로 변경
> PageRequestDTO, PageResponseDTO를 사용하여 기존의 BoothDTO를 반환

## 📷 Screenshot
![image](https://user-images.githubusercontent.com/80760160/228169524-444c61e8-e4b0-40ba-878b-5bf93d6c8b60.png)

## 🔗 Issue number and link
- closed #30 