### PR TITLE
단방향 참조 -> 양방향 참조로 변경

### DIFF
--- a/src/main/java/com/hallym/festival/domain/booth/entity/Booth.java
+++ b/src/main/java/com/hallym/festival/domain/booth/entity/Booth.java
@@ -10,10 +10,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Getter
 @AllArgsConstructor
@@ -55,6 +52,7 @@ public class Booth extends BaseTimeEntity {
     @ColumnDefault("false") //삭제 여부
     private boolean is_deleted;
 
+    @Builder.Default
     @JsonManagedReference
     @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
@@ -113,5 +111,4 @@ public class Booth extends BaseTimeEntity {
     public void setIs_deleted(Boolean is_deleted){
         this.is_deleted = is_deleted;
     }
-
 }

--- a/src/main/java/com/hallym/festival/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hallym/festival/domain/comment/entity/Comment.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id")
+    @Column(name = "cno")
     private Long cno;
 
     @NotNull
@@ -35,19 +35,27 @@ public class Comment extends BaseTimeEntity {
     @NotNull //삭제 여부
     private Boolean is_deleted;
 
+    @Builder.Default
     @JsonManagedReference(value="comment") // 부모클래스S
     @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
     private List<CommentReport> commentReportList = new ArrayList<>();
 
     @JsonBackReference // 자식클래스
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "booth_id")
+    @JoinColumn(name = "bno", nullable = false)
     private Booth booth;
 
     public void setIs_deleted(Boolean is_deleted){
         this.is_deleted = is_deleted;
     }
 
+    public void setBooth(Booth booth) {
+        if (this.booth != null) { //기존에 부스가 존재한다면
+            this.booth.getComments().remove(this); //관계를 끊는다.
+        }
+        this.booth = booth;
+        booth.getComments().add(this);
+    }
 }
 
 

--- a/src/main/java/com/hallym/festival/domain/commentreport/entity/CommentReport.java
+++ b/src/main/java/com/hallym/festival/domain/commentreport/entity/CommentReport.java
@@ -17,7 +17,7 @@ import javax.persistence.*;
 public class CommentReport {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Rno;
+    private Long crno;
 
     @NotNull
     private String cookieKey;
@@ -25,6 +25,14 @@ public class CommentReport {
     //json backreferecne 2개 넣으면 오류난대서 value 지정하기.
     @JsonBackReference(value="comment") //부모클래스에 JsonBackReference 붙여서 순환참조 방어.
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
+    @JoinColumn(name = "cno")
     private Comment comment;
+
+    public void setComment(Comment comment) {
+        if (this.comment != null) {
+            this.comment.getCommentReportList().remove(this);
+        }
+        this.comment = comment;
+        comment.getCommentReportList().add(this);
+    }
 }

--- a/src/main/java/com/hallym/festival/domain/commentreport/service/CommentReportServiceImpl.java
+++ b/src/main/java/com/hallym/festival/domain/commentreport/service/CommentReportServiceImpl.java
@@ -67,7 +67,10 @@ public class CommentReportServiceImpl implements CommentReportService {
 
     private CommentReport createCommentCookie(Comment comment) {
         String newCookieKey = createCookieKey();
-        CommentReport commentReport = CommentReport.builder().comment(comment).cookieKey(newCookieKey).build();
+        CommentReport commentReport = CommentReport.builder()
+                .cookieKey(newCookieKey)
+                .build();
+        commentReport.setComment(comment); //연관관계 참조
         commentReportRepository.save(commentReport);
         return commentReport;
     }

--- a/src/main/java/com/hallym/festival/domain/likes/dto/LikesResponseDTO.java
+++ b/src/main/java/com/hallym/festival/domain/likes/dto/LikesResponseDTO.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LikesResponseDTO {
-    private Long boothId;
+    private Long bno;
     private String cookieKey;
 
 }

--- a/src/main/java/com/hallym/festival/domain/likes/entity/Likes.java
+++ b/src/main/java/com/hallym/festival/domain/likes/entity/Likes.java
@@ -18,14 +18,21 @@ import javax.persistence.*;
 public class Likes {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
-    private Long id;
+    private Long lno;
 
     @NotNull
     private String cookieKey;
 
-    @NotNull
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "booth_id")
+    @JoinColumn(name = "bno")
     private Booth booth;
+
+    public void setBooth(Booth booth) {
+        if (this.booth != null) { //기존에 부스가 존재한다면
+            this.booth.getComments().remove(this); //관계를 끊는다.
+        }
+        this.booth = booth;
+        booth.getLikes().add(this);
+    }
 }

--- a/src/main/java/com/hallym/festival/domain/totalvisit/entity/TotalVisit.java
+++ b/src/main/java/com/hallym/festival/domain/totalvisit/entity/TotalVisit.java
@@ -22,7 +22,7 @@ public class TotalVisit {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "totalvisit_id")
+    @Column(name = "tno")
     private Long tno;
 
     @CreatedDate //생성시간 자동저장

--- a/src/main/java/com/hallym/festival/domain/visitcomment/entity/VisitComment.java
+++ b/src/main/java/com/hallym/festival/domain/visitcomment/entity/VisitComment.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class VisitComment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "visitcomment_id")
+    @Column(name = "vno")
     private Long vno;
 
     @NotNull
@@ -34,6 +34,7 @@ public class VisitComment extends BaseTimeEntity {
     @NotNull //삭제 여부
     private Boolean is_deleted;
 
+    @Builder.Default
     @JsonManagedReference(value="visit") //부모클래스에 JsonManagedReference 붙여서 순환참조 방어.
     @OneToMany(mappedBy = "visitComment", fetch = FetchType.LAZY)
     private List<VisitCommentReport> visitCommentReports = new ArrayList<>();

--- a/src/main/java/com/hallym/festival/domain/visitcommentreport/entity/VisitCommentReport.java
+++ b/src/main/java/com/hallym/festival/domain/visitcommentreport/entity/VisitCommentReport.java
@@ -17,7 +17,8 @@ import javax.persistence.*;
 public class VisitCommentReport {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Rno;
+    @Column(name = "vcrno")
+    private Long vcrno;
 
     @NotNull
     private String cookieKey;
@@ -25,6 +26,14 @@ public class VisitCommentReport {
     //json backreferecne 2개 넣으면 오류난대서 value 지정하기.
     @JsonBackReference(value="visitcomment") //부모클래스에 JsonBackReference 붙여서 순환참조 방어.
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "visitcomment_id")
+    @JoinColumn(name = "vno")
     private VisitComment visitComment;
+
+    public void setVisitComment(VisitComment visitComment) {
+        if (this.visitComment != null) {
+            this.visitComment.getVisitCommentReports().remove(this);
+        }
+        this.visitComment = visitComment;
+        visitComment.getVisitCommentReports().add(this);
+    }
 }

--- a/src/main/java/com/hallym/festival/domain/visitcommentreport/service/VisitCommentReportServiceImpl.java
+++ b/src/main/java/com/hallym/festival/domain/visitcommentreport/service/VisitCommentReportServiceImpl.java
@@ -67,7 +67,11 @@ public class VisitCommentReportServiceImpl implements VisitCommentReportService{
 
     private VisitCommentReport createVisitCommentCookie(VisitComment visitComment) {
         String newCookieKey = createCookieKey();
-        VisitCommentReport visitCommentReport = VisitCommentReport.builder().visitComment(visitComment).cookieKey(newCookieKey).build();
+        VisitCommentReport visitCommentReport = VisitCommentReport.builder()
+                .cookieKey(newCookieKey)
+                .build();
+        
+        visitCommentReport.setVisitComment(visitComment); //연관관계 참조
         visitCommentReportRepository.save(visitCommentReport);
         return visitCommentReport;
     }
@@ -83,7 +87,7 @@ public class VisitCommentReportServiceImpl implements VisitCommentReportService{
     }
 
     private String createRandomString(){
-        int targetStringLength = 8;
+        int targetStringLength = 10;
         Random random = new Random();
         return random.ints(97, 123)
                 .limit(targetStringLength)

--- a/src/test/java/com/hallym/festival/repository/BoothRepositoryTests.java
+++ b/src/test/java/com/hallym/festival/repository/BoothRepositoryTests.java
@@ -46,6 +46,7 @@ public class BoothRepositoryTests {
 					.booth_title("부스명..." + i)
 					.booth_content("동아리 소개..." + i)
 					.booth_type(BoothType.푸드트럭)
+					.booth_active(BoothActive.OPEN)
 					.writer("부스담당매니저" + (i % 5))
 					.build());
 


### PR DESCRIPTION
## ☑️ Describe your changes
- 내가 맡은 Entity들 양방향 참조관계로 변경 (DB에는 변경사항이 없지만 객체관계에서 양방향으로 참조 가능) 
- 양방향 참조의 단점?(주의해야할 점)을 보완하기 위해 기존에 부모객체가 있는지 확인
   - 참고자료 -> https://zzerosouth.tistory.com/18
- Entity의 id들 고유명으로 변경 Ex(visitcomment_id = vno, visitcommentreportid = vcrno)
- 양방향 매핑관계 테스트

## 📷 Screenshot
### 부스와 댓글의 양방향 관계를 댓글쪽에서 맺어줌
![image](https://user-images.githubusercontent.com/52206904/230755580-f48edf07-3bf4-491f-9349-2e3c9210e2aa.png)
### 위처럼 양방향 관계를 안해주면 아래 테스트처럼 booth객체의 Comment가 안들어감. (하지만 DB에는 정상반영)
![image](https://user-images.githubusercontent.com/52206904/230755647-ec2a2e58-4eb3-46a8-b9c8-218c12a2493a.png)
![image](https://user-images.githubusercontent.com/52206904/230755677-bf727a60-39a2-4ce5-a258-cbaddf4b0184.png)
### 하지만 연관관계 세팅을 해주면 아래 테스트가 통과.
![image](https://user-images.githubusercontent.com/52206904/230755736-bddd0aa2-1319-4f83-a9dd-f2478c465add.png)
### 부스 좋아요 쿠키값 변경
- 기존에 1, 2, 3으로 저장한 쿠키값을 bno1, bno2로 변경
![image](https://user-images.githubusercontent.com/52206904/230755948-97fd1184-5b15-45c7-9a13-c84d6b4cb03d.png)
![image](https://user-images.githubusercontent.com/52206904/230755929-aff2e6d6-4ed5-4422-99dd-d85d8ed6bd46.png)




## ETC (2시간동안 못찾은 에러..ㅜㅜ)
- Builder.Default 를 다음과 같이 안해주면 Builder로 객체 생성시 리스트 초기화가 안되어 null pointer exception 발생
![image](https://user-images.githubusercontent.com/52206904/230755803-bd9a841d-effe-4614-b5f0-96783f14a374.png)


## 🔗 Issue number and link
- #70 
