### PR TITLE
메뉴 품절 여부에 대한 컬럼 추가 및 notice service 수정

### DIFF
--- a/src/main/java/com/hallym/festival/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/hallym/festival/domain/menu/controller/MenuController.java
@@ -39,4 +39,10 @@ public class MenuController {
         String result = menuService.delete(mno);
         return Map.of("result", result);
     }
+
+    @PutMapping("sell/{mno}")
+    public Map<String, String> modifySell(@PathVariable(name = "mno") Long mno) {
+        String result = menuService.modifySoldOut(mno);
+        return Map.of("result", result);
+    }
 }

--- a/src/main/java/com/hallym/festival/domain/menu/dto/MenuRequestDto.java
+++ b/src/main/java/com/hallym/festival/domain/menu/dto/MenuRequestDto.java
@@ -1,6 +1,7 @@
 package com.hallym.festival.domain.menu.dto;
 
 import com.hallym.festival.domain.booth.entity.Booth;
+import com.hallym.festival.domain.menu.entity.MenuSell;
 import lombok.*;
 
 
@@ -14,4 +15,5 @@ public class MenuRequestDto {
     private Long price;
     private Boolean is_deleted;
     private Booth booth;
+    private MenuSell menuSell;
 }

--- a/src/main/java/com/hallym/festival/domain/menu/dto/MeunResponseDto.java
+++ b/src/main/java/com/hallym/festival/domain/menu/dto/MeunResponseDto.java
@@ -1,5 +1,6 @@
 package com.hallym.festival.domain.menu.dto;
 
+import com.hallym.festival.domain.menu.entity.MenuSell;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,4 +14,5 @@ public class MeunResponseDto {
     private Long mno;
     private String name;
     private Long price;
+    private MenuSell menuSell;
 }

--- a/src/main/java/com/hallym/festival/domain/menu/entity/Menu.java
+++ b/src/main/java/com/hallym/festival/domain/menu/entity/Menu.java
@@ -35,8 +35,15 @@ public class Menu extends BaseTimeEntity {
     @JoinColumn(name = "bno")
     private Booth booth;
 
+    @Enumerated(EnumType.STRING)
+    private MenuSell menuSell;
+
     public void setIs_deleted(Boolean is_deleted) {
         this.is_deleted = is_deleted;
+    }
+
+    public void setMenuSell(MenuSell menuSell) {
+        this.menuSell = menuSell;
     }
 
     public void updateMenu(Menu menu) {

--- a/src/main/java/com/hallym/festival/domain/menu/entity/MenuSell.java
+++ b/src/main/java/com/hallym/festival/domain/menu/entity/MenuSell.java
@@ -3,7 +3,7 @@ package com.hallym.festival.domain.menu.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum MenuSell {
-    SOID, SELL;
+    SOLD, SELL;
 
     @JsonCreator
     public static MenuSell from(String s) {

--- a/src/main/java/com/hallym/festival/domain/menu/entity/MenuSell.java
+++ b/src/main/java/com/hallym/festival/domain/menu/entity/MenuSell.java
@@ -1,0 +1,12 @@
+package com.hallym.festival.domain.menu.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum MenuSell {
+    SOID, SELL;
+
+    @JsonCreator
+    public static MenuSell from(String s) {
+        return MenuSell.valueOf(s);
+    }
+}

--- a/src/main/java/com/hallym/festival/domain/menu/service/MenuService.java
+++ b/src/main/java/com/hallym/festival/domain/menu/service/MenuService.java
@@ -14,4 +14,6 @@ public interface MenuService {
     MeunResponseDto modify(Long mno, MenuRequestDto MenuRequestDto);
 
     String delete(Long mno);
+
+    String modifySoldOut(Long mno);
 }

--- a/src/main/java/com/hallym/festival/domain/menu/service/MenuServicelmpl.java
+++ b/src/main/java/com/hallym/festival/domain/menu/service/MenuServicelmpl.java
@@ -64,7 +64,7 @@ public class MenuServicelmpl implements MenuService {
         Menu menu = byMno.orElseThrow();
 
         if(menu.getMenuSell() == MenuSell.SELL) {
-            menu.setMenuSell(MenuSell.SOID);
+            menu.setMenuSell(MenuSell.SOLD);
             menuRepository.save(menu);
             return "Menu is sold out";
         } else {

--- a/src/main/java/com/hallym/festival/domain/menu/service/MenuServicelmpl.java
+++ b/src/main/java/com/hallym/festival/domain/menu/service/MenuServicelmpl.java
@@ -5,6 +5,7 @@ import com.hallym.festival.domain.booth.repository.BoothRepository;
 import com.hallym.festival.domain.menu.dto.MenuRequestDto;
 import com.hallym.festival.domain.menu.dto.MeunResponseDto;
 import com.hallym.festival.domain.menu.entity.Menu;
+import com.hallym.festival.domain.menu.entity.MenuSell;
 import com.hallym.festival.domain.menu.repository.MenuRepository;
 import com.hallym.festival.global.exception.WrongBoothId;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,9 @@ public class MenuServicelmpl implements MenuService {
     @Transactional
     public MeunResponseDto create(Long bno, MenuRequestDto menuRequestDto) {
         Optional<Booth> booth = boothRepository.findById(bno);
-        menuRequestDto.setBooth(booth.get());
         Menu newMenu = modelMapper.map(menuRequestDto, Menu.class);
+        newMenu.setBooth(booth.get());
+        newMenu.setMenuSell(MenuSell.SELL);
         menuRepository.save(newMenu);
         return modelMapper.map(newMenu, MeunResponseDto.class);
     }
@@ -54,6 +56,24 @@ public class MenuServicelmpl implements MenuService {
         menu.setIs_deleted(Boolean.TRUE);
         return "delete success";
     }
+
+    @Override
+    public String modifySoldOut(Long mno) {
+        Optional<Menu> byMno = menuRepository.findById(mno);
+
+        Menu menu = byMno.orElseThrow();
+
+        if(menu.getMenuSell() == MenuSell.SELL) {
+            menu.setMenuSell(MenuSell.SOID);
+            menuRepository.save(menu);
+            return "Menu is sold out";
+        } else {
+            menu.setMenuSell(MenuSell.SELL);
+            menuRepository.save(menu);
+            return "Menu is sell";
+        }
+    }
+
 
     public List<MeunResponseDto> getMenuList(List<Menu> all) {
         return all.stream().map(menu -> this.toDto(menu)).collect(Collectors.toList());

--- a/src/main/java/com/hallym/festival/domain/notice/service/NoticeServicelmpl.java
+++ b/src/main/java/com/hallym/festival/domain/notice/service/NoticeServicelmpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -55,7 +56,8 @@ public class NoticeServicelmpl implements NoticeService {
     }
 
     public String delete(Long nno) { //공지사항 삭제
-        Notice notice = findByNotice(nno);
+        Optional<Notice> byNno = noticeRepository.findById(nno);
+        Notice notice = byNno.get();
         notice.setIs_deleted(Boolean.TRUE);
         return "delete success";
     }

--- a/src/test/java/com/hallym/festival/service/MenuServiceTests.java
+++ b/src/test/java/com/hallym/festival/service/MenuServiceTests.java
@@ -89,4 +89,10 @@ public class MenuServiceTests {
         menuService.create(bno, menuRequestDto);
 
     }
+
+    @Test
+    public void testSoldOut() {
+        Long mno = 1L;
+        menuService.modifySoldOut(mno);
+    }
 }


### PR DESCRIPTION
## ☑️ Describe your changes
- 메뉴 품절 여부에 대한 컬럼 추가
- 품절 여부에 대한 api 생성
- 공지사항 삭제 service 수정

## 📷 Screenshot
![image](https://user-images.githubusercontent.com/112682489/235963033-0405b824-9ed9-4a59-a755-7deb25a6cb76.png)
품절 여부에 대한 api를 한 번 실행한 경우(품절 되었을 때)
![image](https://user-images.githubusercontent.com/112682489/235963300-81b1abb9-123c-4eb4-ae69-0df3f60d0969.png)
품절 여부에 대한 api를 두 번 실행한 경우(판매를 시작할 때)
![image](https://user-images.githubusercontent.com/112682489/235963528-499a9079-59b2-45f7-bd73-8b9dd5c5114f.png)
![image](https://user-images.githubusercontent.com/112682489/235963852-0608016d-a9ab-4259-afc9-feb9fb4b9967.png)


## 🔗 Issue number and link
- 피드백 들어온 걸로 바로 수정하여 이슈는 등록하지 않았습니다.