### PR TITLE
refactor : UploadController에서 originalName에 "_" 제거 후 link 생성 처리

### DIFF
--- a/src/main/java/com/hallym/festival/domain/booth/controller/UploadController.java
+++ b/src/main/java/com/hallym/festival/domain/booth/controller/UploadController.java
@@ -45,6 +45,9 @@ public class UploadController {
 
                 String uuid = UUID.randomUUID().toString();
 
+                // "_" 제거
+                originalName = originalName.replaceAll("_", "");
+
                 Path savePath = Paths.get(uploadPath, uuid+"_"+ originalName);
 
                 boolean image = false;


### PR DESCRIPTION
## ☑️ Describe your changes
- 첨부파일 저장 시 "_"로 구분하여 uuid와 originalName 문자열을 생성할 때, originalName이 잘못된 형식으로 저장되는 상황  
- UploadController에서 originalName에 "_" 제거 후 link 생성 처리하게끔 메소드 수정

## 📷 Screenshot
![image](https://user-images.githubusercontent.com/80760160/236812701-aa156468-b62c-4ef9-b485-f13c56b20894.png)

## 🔗 Issue number and link
- #41 