### PR TITLE
hotfix - v4

### DIFF
--- a/src/main/java/com/hallym/festival/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hallym/festival/domain/comment/controller/CommentController.java
@@ -27,8 +27,7 @@ public class CommentController {
         return responseDTO;
     }
 
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/auth/top-count-list")
+    @GetMapping("/top-count-list")
     public PageResponseDTO<CommentTopCountDTO> getTopCommentBoothList(PageRequestDTO pageRequestDTO) {
         PageResponseDTO<CommentTopCountDTO> responseDTO = commentService.getTopCountList(pageRequestDTO);
         return responseDTO;

--- a/src/main/java/com/hallym/festival/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/hallym/festival/domain/comment/service/CommentServiceImpl.java
@@ -133,7 +133,7 @@ public class CommentServiceImpl implements CommentService{
                 pageRequestDTO.getPage()-1,
                 pageRequestDTO.getSize());
 
-        Page<Booth> result = boothRepository.listTopCommentBooth(Boolean.FALSE, pageable);
+        Page<Booth> result = boothRepository.listTopCommentBooth(Boolean.FALSE, false,  pageable);
         List<CommentTopCountDTO> dtoList = result.getContent()
                 .stream()
                 .map(this::BoothToCommentTopCountListDTO)

--- a/src/main/java/com/hallym/festival/domain/likes/controller/LikeController.java
+++ b/src/main/java/com/hallym/festival/domain/likes/controller/LikeController.java
@@ -30,8 +30,7 @@ public class LikeController {
         return Map.of("result", result);
     }
 
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/auth/top-count-list")
+    @GetMapping("/top-count-list")
     public PageResponseDTO<LikesResponseTopDTO> getTopLikeBoothList(PageRequestDTO pageRequestDTO) {
         PageResponseDTO<LikesResponseTopDTO> responseDTO = likeService.getTopLikeBoothList(pageRequestDTO);
         return responseDTO;

--- a/src/main/java/com/hallym/festival/domain/likes/service/LikeServiceImpl.java
+++ b/src/main/java/com/hallym/festival/domain/likes/service/LikeServiceImpl.java
@@ -77,7 +77,7 @@ public class LikeServiceImpl implements LikeService{
                 pageRequestDTO.getPage()-1,
                 pageRequestDTO.getSize());
 
-        Page<Booth> result = boothRepository.listTopLikeBooth(pageable);
+        Page<Booth> result = boothRepository.listTopLikeBooth(false, pageable);
         List<LikesResponseTopDTO> dtoList = result.getContent()
                 .stream()
                 .map(this::BoothToLikesTopResponseDto)


### PR DESCRIPTION
## ☑️ Describe your changes
- 일반 유저에게도 댓글 개수별, 좋아요 개수별 부스목록 페이징해서 보여줌
- 페이징에서 페이지마다 겹치는 부스 한두개 있던 것 order by 1번 더 해줌으로써 해결
- 위를 위해 어드민만 접근가능한  접근권한 API 해제

## 📷 Screenshot
![image](https://github.com/Hallym-LIKELION/HallymFestival2023-Backend-/assets/52206904/6151fe26-532b-4844-84e2-7c583f3823ce)
![image](https://github.com/Hallym-LIKELION/HallymFestival2023-Backend-/assets/52206904/5d56a24f-f624-4aa4-94d2-8bf4676300db)
![image](https://github.com/Hallym-LIKELION/HallymFestival2023-Backend-/assets/52206904/7a6c2856-60b3-4cc8-b3d6-db1725c87541)


## 🔗 Issue number and link
- #96 